### PR TITLE
Paint refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ OBJS += vmath.o
 OBJS += assets.o shader.o face.o shaderinfo.o blur.o shadow.o texture.o include.o
 OBJS += renderutil.o textureeffects.o framebuffer.o zone.o render.o renderbuffer.o
 OBJS += window.o
+OBJS += xorg.o
 
 ifneq "$(GLX_MARK)" ""
     CFG += -DDEBUG_GLX_MARK

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ INCS =
 OBJS = compton.o
 
 # === Configuration flags ===
-CFG = -std=gnu11
+CFG = -std=gnu11 -fms-extensions
 
 # -lGL must precede some other libraries, or it segfaults on FreeBSD (#74)
 LIBS := -lGL $(LIBS)
@@ -26,7 +26,7 @@ OBJS += vmath.o
 OBJS += assets.o shader.o face.o shaderinfo.o blur.o shadow.o texture.o include.o
 OBJS += renderutil.o textureeffects.o framebuffer.o zone.o render.o renderbuffer.o
 OBJS += window.o
-OBJS += xorg.o
+OBJS += xorg.o xtexture.o
 
 ifneq "$(GLX_MARK)" ""
     CFG += -DDEBUG_GLX_MARK

--- a/src/blur.c
+++ b/src/blur.c
@@ -48,9 +48,11 @@ bool blur_backbuffer(struct blur* blur, session_t* ps, const Vector2* pos,
 
     // Make sure the blur cache is initialized. This is a noop if it's already
     // initialized
-    if(blur_cache_init(pbc, size) != 0) {
-        printf_errf("(): Failed to initializing cache");
-        return false;
+    if(!vec2_eq(size, &pbc->size)) {
+        if(blur_cache_init(pbc, size) != 0) {
+            printf_errf("(): Failed to initializing cache");
+            return false;
+        }
     }
 
     struct Texture* tex_scr = &pbc->texture[0];

--- a/src/blur.c
+++ b/src/blur.c
@@ -104,19 +104,9 @@ bool blur_backbuffer(struct blur* blur, session_t* ps, const Vector2* pos,
 
     //Final render
     {
-        Vector2 root_size = {{ps->root_width, ps->root_height}};
-        Vector2 pixeluv = {{1.0f, 1.0f}};
-        vec2_div(&pixeluv, &root_size);
-
         Vector2 rectPos = *pos;
         Vector2 rectSize = *size;
         Vector2 glRectPos = X11_rectpos_to_gl(ps, &rectPos, &rectSize);
-
-        Vector2 scale = pixeluv;
-        vec2_mul(&scale, &rectSize);
-
-        Vector2 relpos = pixeluv;
-        vec2_mul(&relpos, &glRectPos);
 
 #ifdef DEBUG_GLX
         printf_dbgf("glpos: %f %f, relpos %f %f scale %f %f\n",
@@ -124,7 +114,7 @@ bool blur_backbuffer(struct blur* blur, session_t* ps, const Vector2* pos,
                 scale.y);
 #endif
 
-        draw_rect(ps->psglx->blur.face, passthough_type->mvp, relpos, scale);
+        draw_rect(ps->psglx->blur.face, passthough_type->mvp, glRectPos, rectSize);
     }
 
     // Restore the default rendering context

--- a/src/blur.c
+++ b/src/blur.c
@@ -54,7 +54,7 @@ bool blur_backbuffer(struct blur* blur, session_t* ps, const Vector2* pos,
     }
 
     struct Texture* tex_scr = &pbc->texture[0];
-	win_calculate_blur(blur, ps, w);
+    win_calculate_blur(blur, ps, w);
 
     glViewport(0, 0, ps->root_width, ps->root_height);
 

--- a/src/blur.c
+++ b/src/blur.c
@@ -5,6 +5,7 @@
 #include "assets/shader.h"
 #include "shaders/shaderinfo.h"
 #include "renderutil.h"
+#include "window.h"
 #include "textureeffects.h"
 #include "framebuffer.h"
 
@@ -37,7 +38,7 @@ static Vector2 X11_rectpos_to_gl(session_t *ps, const Vector2* xpos, const Vecto
 
 bool blur_backbuffer(struct blur* blur, session_t* ps, const Vector2* pos,
         const Vector2* size, float z, GLfloat factor_center,
-        glx_blur_cache_t* pbc) {
+        glx_blur_cache_t* pbc, win* w) {
     glx_mark(ps, 0xDEADBEEF, true);
 #ifdef DEBUG_GLX
     printf_dbgf("(): %f, %f, %f, %f\n", pos->x, pos->y, size->x, size->y);
@@ -53,40 +54,7 @@ bool blur_backbuffer(struct blur* blur, session_t* ps, const Vector2* pos,
     }
 
     struct Texture* tex_scr = &pbc->texture[0];
-    if(pbc->damaged) {
-        // Read destination pixels into a texture
-
-        Vector2 glpos = X11_rectpos_to_gl(ps, pos, size);
-        texture_read_from(tex_scr, 0, GL_BACK, &glpos, size);
-
-        // Texture scaling factor
-        Vector2 pixeluv = {{1.0f, 1.0f}};
-        vec2_div(&pixeluv, &tex_scr->size);
-        Vector2 halfpixel = pixeluv;
-        vec2_idiv(&halfpixel, 2);
-
-        // Disable the options. We will restore later
-        glDisable(GL_STENCIL_TEST);
-        glDisable(GL_SCISSOR_TEST);
-
-        int level = ps->o.blur_level;
-
-        struct TextureBlurData blurData = {
-            .buffer = &blur->fbo,
-            .swap = &pbc->texture[1],
-        };
-        // Do the blur
-        if(!texture_blur(&blurData, tex_scr, level, false)) {
-            printf_errf("Failed blurring the background texture");
-
-            if (have_scissors)
-                glEnable(GL_SCISSOR_TEST);
-            if (have_stencil)
-                glEnable(GL_STENCIL_TEST);
-            return false;
-        }
-        pbc->damaged = false;
-    }
+	win_calculate_blur(blur, ps, w);
 
     glViewport(0, 0, ps->root_width, ps->root_height);
 

--- a/src/blur.h
+++ b/src/blur.h
@@ -31,7 +31,7 @@ void blur_destroy(struct blur* blur);
 
 bool blur_backbuffer(struct blur* blur, session_t* ps, const Vector2* pos,
         const Vector2* size, float z, GLfloat factor_center,
-        glx_blur_cache_t* pbc);
+        glx_blur_cache_t* pbc, win* w);
 
 int blur_cache_init(glx_blur_cache_t* cache, const Vector2* size);
 void blur_cache_delete(glx_blur_cache_t* cache);

--- a/src/common.h
+++ b/src/common.h
@@ -1125,8 +1125,6 @@ typedef struct _win {
   bool pixmap_damaged;
   /// Damage of the window.
   Damage damage;
-  /// Paint info of the window.
-  paint_t paint;
   /// Bounding shape of the window.
   XserverRegion border_size;
   /// Window flags. Definitions above.
@@ -2273,14 +2271,6 @@ free_texture(session_t *ps, glx_texture_t **pptex) {
 static inline void
 free_paint_glx(session_t *ps, paint_t *ppaint) {
   free_texture(ps, &ppaint->ptex);
-}
-
-/**
- * Free GLX part of win.
- */
-static inline void
-free_win_res_glx(session_t *ps, win *w) {
-  free_paint_glx(ps, &w->paint);
 }
 
 /**

--- a/src/common.h
+++ b/src/common.h
@@ -139,6 +139,16 @@ struct blur {
     GLuint array;
 };
 
+struct WindowDrawable {
+    struct X11Context* context;
+    Window wid;
+
+    bool bound;
+    Pixmap pixmap;
+    GLXDrawable glxPixmap;
+    struct Texture texture;
+};
+
 typedef struct {
   /// Framebuffer used for blurring.
   struct Framebuffer fbo;
@@ -1235,6 +1245,8 @@ typedef struct _win {
   glx_blur_cache_t glx_blur_cache;
 
   struct glx_shadow_cache shadow_cache;
+
+  struct WindowDrawable drawable;
 } win;
 
 /// Temporary structure used for communication between

--- a/src/common.h
+++ b/src/common.h
@@ -125,6 +125,7 @@
 #include "vmath.h"
 #include "texture.h"
 #include "framebuffer.h"
+#include "xorg.h"
 
 // @CLEANUP @HACK We don't actually want this here, but because everything is in
 // here i do now.
@@ -816,7 +817,10 @@ typedef struct {
   Matrix view;
   /// FBConfig-s for GLX pixmap of different depths.
   glx_fbconfig_t *fbconfigs[OPENGL_MAX_DEPTH + 1];
+
   glx_blur_pass_t blur_passes[MAX_BLUR_PASS];
+
+  struct X11Context xcontext;
 } glx_session_t;
 
 #define CGLX_SESSION_INIT { .context = NULL }

--- a/src/common.h
+++ b/src/common.h
@@ -1072,6 +1072,8 @@ typedef struct _win {
   struct _win *next;
   /// Pointer to the next higher window to paint.
   struct _win *prev_trans;
+  /// Pointer to the next lower window to paint.
+  struct _win *next_trans;
 
   // Core members
   /// ID of the top-level frame window.
@@ -2158,7 +2160,7 @@ glx_set_clip(session_t *ps, XserverRegion reg, const reg_data_t *pcache_reg);
 
 bool
 glx_blur_dst(session_t *ps, const Vector2* pos, const Vector2* size, float z,
-    GLfloat factor_center, glx_blur_cache_t *pbc);
+    GLfloat factor_center, glx_blur_cache_t *pbc, win* w);
 
 bool
 glx_dim_dst(session_t *ps, int dx, int dy, int width, int height, float z,

--- a/src/compton.c
+++ b/src/compton.c
@@ -2256,8 +2256,11 @@ configure_win(session_t *ps, XConfigureEvent *ce) {
     w->a.y = ce->y;
 
     if (w->a.width != ce->width || w->a.height != ce->height
-        || w->a.border_width != ce->border_width)
+        || w->a.border_width != ce->border_width) {
       free_wpaint(ps, w);
+      wd_unbind(&w->drawable);
+      wd_bind(&w->drawable);
+    }
 
     if (w->a.width != ce->width || w->a.height != ce->height
         || w->a.border_width != ce->border_width) {

--- a/src/compton.c
+++ b/src/compton.c
@@ -628,7 +628,8 @@ static void paint_root(session_t *ps) {
     glViewport(0, 0, ps->root_width, ps->root_height);
 
     struct face* face = assets_load("window.face");
-    draw_tex(ps, face, &ps->root_texture.texture, &VEC2_ZERO, &VEC2_UNIT);
+    Vector2 rootSize = {{ps->root_width, ps->root_height}};
+    draw_tex(ps, face, &ps->root_texture.texture, &VEC2_ZERO, &rootSize);
 }
 
 /**

--- a/src/compton.c
+++ b/src/compton.c
@@ -1470,6 +1470,11 @@ map_win(session_t *ps, Window id) {
     cdbus_ev_win_mapped(ps, w);
   }
 #endif
+
+  if(!wd_bind(&w->drawable)) {
+      printf_errf("Failed binding window drawable");
+      return;
+  }
 }
 
 static void
@@ -2093,16 +2098,21 @@ add_win(session_t *ps, Window id, Window prev) {
   new->a.map_state = IsUnmapped;
 
   if (InputOutput == new->a.class) {
-       // Get window picture format
-    new->pictfmt = XRenderFindVisualFormat(ps->dpy, new->a.visual);
+      // Get window picture format
+      new->pictfmt = XRenderFindVisualFormat(ps->dpy, new->a.visual);
 
-       // Create Damage for window
-       set_ignore_next(ps);
-       new->damage = XDamageCreate(ps->dpy, id, XDamageReportNonEmpty);
+      // Create Damage for window
+      set_ignore_next(ps);
+      new->damage = XDamageCreate(ps->dpy, id, XDamageReportNonEmpty);
   }
 
   calc_win_size(ps, new);
 
+  if(!wd_init(&new->drawable, &ps->psglx->xcontext, new->id)) {
+      printf_errf("Failed initializing window drawable");
+      free(new);
+      return false;
+  }
   new->next = *p;
   *p = new;
 
@@ -2114,7 +2124,7 @@ add_win(session_t *ps, Window id, Window prev) {
 #endif
 
   if (IsViewable == map_state) {
-    map_win(ps, id);
+      map_win(ps, id);
   }
 
   return true;

--- a/src/compton.c
+++ b/src/compton.c
@@ -2318,7 +2318,6 @@ finish_destroy_win(session_t *ps, Window id) {
       printf_dbgf("(%#010lx \"%s\"): %p\n", id, w->name, w);
 #endif
 
-      finish_unmap_win(ps, w);
       *prev = w->next;
 
       // Clear active_win if it's pointing to the destroyed window
@@ -2356,8 +2355,6 @@ destroy_win(session_t *ps, Window id) {
 #endif
 
   if (w) {
-    unmap_win(ps, w);
-
     w->destroyed = true;
 
     if (ps->o.no_fading_destroyed_argb)

--- a/src/compton.c
+++ b/src/compton.c
@@ -2361,6 +2361,8 @@ destroy_win(session_t *ps, Window id) {
       win_determine_fade(ps, w);
 
     // Set fading callback
+    // @LEAK @PERFORMANCE: We override the unmap callback here, and never call
+    // it.
     set_fade_callback(ps, w, destroy_callback, false);
 
 #ifdef CONFIG_DBUS

--- a/src/compton.h
+++ b/src/compton.h
@@ -301,19 +301,6 @@ free_win_res(session_t *ps, win *w) {
 }
 
 /**
- * Free root tile related things.
- */
-static inline void
-free_root_tile(session_t *ps) {
-  free_picture(ps, &ps->root_tile_paint.pict);
-  free_texture(ps, &ps->root_tile_paint.ptex);
-  if (ps->root_tile_fill)
-    free_pixmap(ps, &ps->root_tile_paint.pixmap);
-  ps->root_tile_paint.pixmap = None;
-  ps->root_tile_fill = false;
-}
-
-/**
  * Get current system clock in milliseconds.
  */
 static inline time_ms_t
@@ -686,25 +673,24 @@ paint_preprocess(session_t *ps, win *list);
 
 static void
 render_(session_t *ps, int x, int y, int dx, int dy, int wid, int hei,
-    double opacity, bool argb, bool neg,
-    Picture pict, glx_texture_t *ptex,
+    double opacity, bool neg,
+    Picture pict, struct Texture* ptex,
     const glx_prog_main_t *pprogram
     );
 
 #define \
-   render(ps, x, y, dx, dy, wid, hei, opacity, argb, neg, pict, ptex, pprogram) \
-  render_(ps, x, y, dx, dy, wid, hei, opacity, argb, neg, pict, ptex, pprogram)
+   render(ps, x, y, dx, dy, wid, hei, opacity, neg, pict, ptex, pprogram) \
+  render_(ps, x, y, dx, dy, wid, hei, opacity, neg, pict, ptex, pprogram)
 
 static inline void
 win_render(session_t *ps, win *w, int x, int y, int wid, int hei,
     double opacity, Picture pict) {
   const int dx = (w ? w->a.x: 0) + x;
   const int dy = (w ? w->a.y: 0) + y;
-  const bool argb = (w && (WMODE_ARGB == w->mode || ps->o.force_win_blend));
   const bool neg = (w && w->invert_color);
 
-  render(ps, x, y, dx, dy, wid, hei, opacity, argb, neg,
-      pict, (w ? w->paint.ptex: ps->root_tile_paint.ptex),
+  render(ps, x, y, dx, dy, wid, hei, opacity, neg,
+      pict, (w ? &w->drawable.texture: &ps->root_texture.texture),
       (w ? &ps->o.glx_prog_win: NULL));
 }
 

--- a/src/opengl.c
+++ b/src/opengl.c
@@ -339,7 +339,6 @@ glx_destroy(session_t *ps) {
 
   // Free all GLX resources of windows
   for (win *w = ps->list; w; w = w->next) {
-    free_win_res_glx(ps, w);
     blur_cache_delete(&w->glx_blur_cache);
     shadow_cache_delete(&w->shadow_cache);
   }

--- a/src/opengl.c
+++ b/src/opengl.c
@@ -286,7 +286,7 @@ glx_init(session_t *ps, bool need_render) {
     }
 
     // Clear screen
-    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
     // glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     // glXSwapBuffers(ps->dpy, get_tgt_window(ps));
   }

--- a/src/opengl.c
+++ b/src/opengl.c
@@ -928,8 +928,8 @@ glx_set_clip(session_t *ps, XserverRegion reg, const reg_data_t *pcache_reg) {
 bool
 glx_blur_dst(session_t *ps, const Vector2* pos, const Vector2* size, float z,
     GLfloat factor_center,
-    glx_blur_cache_t *pbc) {
-    bool ret = blur_backbuffer(&ps->psglx->blur, ps, pos, size, z, factor_center, pbc);
+    glx_blur_cache_t *pbc, win* w) {
+    bool ret = blur_backbuffer(&ps->psglx->blur, ps, pos, size, z, factor_center, pbc, w);
     glx_check_err(ps);
     return ret;
 }

--- a/src/opengl.c
+++ b/src/opengl.c
@@ -396,7 +396,8 @@ void
 glx_on_root_change(session_t *ps) {
   glViewport(0, 0, ps->root_width, ps->root_height);
 
-  ps->psglx->view = orthogonal(0, ps->root_width, 0, ps->root_height, -1000.0, 1000.0);
+  ps->psglx->view = mat4_orthogonal(0, ps->root_width, 0, ps->root_height, -1000.0, 1000.0);
+  view = ps->psglx->view;
 }
 
 /**
@@ -868,18 +869,12 @@ glx_set_clip(session_t *ps, XserverRegion reg, const reg_data_t *pcache_reg) {
       Vector2 rectSize = {{rects[i].width, rects[i].height}};
       Vector2 glRectPos = X11_rectpos_to_gl(ps, &rectPos, &rectSize);
 
-      Vector2 scale = pixeluv;
-      vec2_mul(&scale, &rectSize);
-
-      Vector2 relpos = pixeluv;
-      vec2_mul(&relpos, &glRectPos);
-
 
 #ifdef DEBUG_GLX
       printf_dbgf("(): Rect %d: %f, %f, %f, %f\n", i, relpos.x, relpos.y, scale.x, scale.y);
 #endif
 
-      draw_rect(face, passthough_type->mvp, relpos, scale);
+      draw_rect(face, passthough_type->mvp, glRectPos, rectSize);
     }
 
     /* glUseProgram(0); */
@@ -1025,11 +1020,6 @@ glx_render_(session_t *ps, const struct Texture* ptex,
   printf_dbgf("(): Draw: %d, %d, %d, %d -> %d, %d (%d, %d) z %d\n", x, y, width, height, dx, dy, ptex->width, ptex->height, z);
 #endif
 
-  // @CLEANUP: remove this
-  Vector2 root_size = {{ps->root_width, ps->root_height}};
-  Vector2 pixeluv = {{1.0f, 1.0f}};
-  vec2_div(&pixeluv, &root_size);
-
   struct face* face = assets_load("window.face");
 
   // Painting
@@ -1038,17 +1028,11 @@ glx_render_(session_t *ps, const struct Texture* ptex,
       Vector2 rectSize = {{width, height}};
       Vector2 glRectPos = X11_rectpos_to_gl(ps, &rectPos, &rectSize);
 
-      Vector2 scale = pixeluv;
-      vec2_mul(&scale, &rectSize);
-
-      Vector2 relpos = pixeluv;
-      vec2_mul(&relpos, &glRectPos);
-
 #ifdef DEBUG_GLX
       printf_dbgf("(): Rect %f, %f, %f, %f\n", relpos.x, relpos.y, scale.x, scale.y);
 #endif
 
-      draw_rect(face, global_type->mvp, relpos, scale);
+      draw_rect(face, global_type->mvp, glRectPos, rectSize);
   }
 
   /* glUseProgram(0); */

--- a/src/opengl.c
+++ b/src/opengl.c
@@ -130,6 +130,18 @@ glx_init(session_t *ps, bool need_render) {
 
   glx_session_t *psglx = ps->psglx;
 
+  if(!xorgContext_init(&psglx->xcontext, ps->dpy, ps->scr)) {
+      printf_errf("Failed initializing the xorg context");
+      goto glx_init_end;
+  }
+
+  int visId = XVisualIDFromVisual(ps->vis);
+  if(!xorgContext_selectConfig(&psglx->xcontext, visId)) {
+      printf_errf("Failed selecting a an fbconfig");
+      goto glx_init_end;
+  }
+  
+
   if (!psglx->context) {
     // Get GLX context
 #ifndef DEBUG_GLX_DEBUG_CONTEXT

--- a/src/opengl.c
+++ b/src/opengl.c
@@ -144,9 +144,6 @@ glx_init(session_t *ps, bool need_render) {
 
   if (!psglx->context) {
     // Get GLX context
-#ifndef DEBUG_GLX_DEBUG_CONTEXT
-    psglx->context = glXCreateContext(ps->dpy, pvis, None, GL_TRUE);
-#else
     {
       GLXFBConfig fbconfig = get_fbconfig_from_visualinfo(ps, pvis);
       if (!fbconfig) {
@@ -173,7 +170,6 @@ glx_init(session_t *ps, bool need_render) {
       psglx->context = p_glXCreateContextAttribsARB(ps->dpy, fbconfig, NULL,
           GL_TRUE, attrib_list);
     }
-#endif
     if (!psglx->context) {
       printf_errf("(): Failed to get GLX context.");
       goto glx_init_end;
@@ -359,6 +355,8 @@ glx_destroy(session_t *ps) {
     free(ps->psglx->fbconfigs[i]);
     ps->psglx->fbconfigs[i] = NULL;
   }
+
+  xorgContext_delete(&ps->psglx->xcontext);
 
   // Destroy GLX context
   if (ps->psglx->context) {

--- a/src/opengl.c
+++ b/src/opengl.c
@@ -990,18 +990,13 @@ void glx_shadow_dst(session_t *ps, win* w, const Vector2* pos, const Vector2* si
  * @brief Render a region with texture data.
  */
 bool
-glx_render_(session_t *ps, const glx_texture_t *ptex,
+glx_render_(session_t *ps, const struct Texture* ptex,
     int x, int y, int dx, int dy, int width, int height, int z,
-    double opacity, bool argb, bool neg,
+    double opacity, bool neg,
     const glx_prog_main_t *pprogram
     ) {
-  if (!ptex || !ptex->texture) {
-    printf_errf("(): Missing texture.");
-    return false;
-  }
+    assert(ptex != NULL);
 
-  argb = argb || (GLX_TEXTURE_FORMAT_RGBA_EXT ==
-      ps->psglx->fbconfigs[ptex->depth]->texture_fmt);
   glEnable(GL_BLEND);
 
   // This is all weird, but X Render is using premultiplied ARGB format, and
@@ -1020,11 +1015,10 @@ glx_render_(session_t *ps, const glx_texture_t *ptex,
   shader_use(global_program);
 
   // Bind texture
-  glActiveTexture(GL_TEXTURE0);
-  glBindTexture(GL_TEXTURE_2D, ptex->texture);
+  texture_bind(ptex, GL_TEXTURE0);
 
   shader_set_uniform_float(global_type->invert, neg);
-  shader_set_uniform_float(global_type->flip, ptex->y_inverted);
+  shader_set_uniform_float(global_type->flip, ptex->flipped);
   shader_set_uniform_float(global_type->opacity, opacity);
   shader_set_uniform_sampler(global_type->tex_scr, 0);
 

--- a/src/pixmap_texture.h
+++ b/src/pixmap_texture.h
@@ -1,7 +1,0 @@
-#pragma once
-
-#define GL_GLEXT_PROTOTYPES
-#include <GL/glx.h>
-
-#include "texture.h"
-

--- a/src/pixmap_texture.h
+++ b/src/pixmap_texture.h
@@ -5,14 +5,3 @@
 
 #include "texture.h"
 
-struct WindowDrawable {
-    Window* window;
-    Pixmap pixmap;
-    GLXDrawable glxPixmap;
-
-    bool bound;
-    struct Texture* texture;
-}
-
-bool wd_init(struct WindowDrawable* drawable, Window* window);
-void wd_delete(struct WindowDrawable* drawable);

--- a/src/pixmap_texture.h
+++ b/src/pixmap_texture.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#define GL_GLEXT_PROTOTYPES
+#include <GL/glx.h>
+
+#include "texture.h"
+
+struct WindowDrawable {
+    Window* window;
+    Pixmap pixmap;
+    GLXDrawable glxPixmap;
+
+    bool bound;
+    struct Texture* texture;
+}
+
+bool wd_init(struct WindowDrawable* drawable, Window* window);
+void wd_delete(struct WindowDrawable* drawable);

--- a/src/renderutil.c
+++ b/src/renderutil.c
@@ -5,23 +5,16 @@
 #include "shaders/shaderinfo.h"
 #include "common.h"
 
+Matrix view;
+
 void draw_rect(struct face* face, GLuint mvp, Vector2 pos, Vector2 size) {
-    Matrix root = IDENTITY_MATRIX;
-    {
-        Matrix op = {{
-        2  , 0  , 0 , 0 ,
-        0  , 2  , 0 , 0 ,
-        0  , 0  , 1 , 0 ,
-        -1 , -1 , 0 , 1 ,
-        }};
-        root = mat4_multiply(&root, &op);
-    }
+    Matrix root = view;
     {
         Matrix op = {{
         size.x , 0      , 0 , 0 ,
         0      , size.y , 0 , 0 ,
         0      , 0      , 1 , 0 ,
-        pos.x  , pos.y  , 0 , 1 ,
+        pos.x  , pos.y  , 1 , 1 ,
         }};
         root = mat4_multiply(&root, &op);
     }

--- a/src/renderutil.c
+++ b/src/renderutil.c
@@ -63,11 +63,5 @@ void draw_tex(session_t* ps, struct face* face, const struct Texture* texture,
 
         draw_rect(face, passthough_type->mvp, *pos, *size);
     }
-
-    // Restore the default rendering context
-    glUseProgram(0);
-
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
-    glBindTexture(GL_TEXTURE_2D, 0);
 }
 

--- a/src/renderutil.c
+++ b/src/renderutil.c
@@ -50,7 +50,7 @@ void draw_tex(session_t* ps, struct face* face, const struct Texture* texture,
     struct Passthough* passthough_type = passthough_program->shader_type;
     shader_use(passthough_program);
 
-    shader_set_uniform_bool(passthough_type->flip, false);
+    shader_set_uniform_bool(passthough_type->flip, texture->flipped);
 
     texture_bind(texture, GL_TEXTURE0);
 

--- a/src/renderutil.h
+++ b/src/renderutil.h
@@ -8,6 +8,8 @@
 #define GL_GLEXT_PROTOTYPES
 #include <GL/glx.h>
 
+extern Matrix view;
+
 void draw_rect(struct face* face, GLuint mvp, Vector2 pos, Vector2 size);
 
 void draw_tex(session_t* ps, struct face* face, const struct Texture* texture,

--- a/src/shadow.c
+++ b/src/shadow.c
@@ -83,7 +83,7 @@ void window_shadow(session_t* ps, win* w, const Vector2* pos, const Vector2* siz
 
     glEnable(GL_BLEND);
 
-    if(!vec2_eq(size, &cache->wSize)) {
+    if(!vec2_eq(size, &cache->wSize) || true) {
         // @BUG: If the size is 0 we will never initialize.
         if(!cache->initialized) {
             shadow_cache_init(cache, size);
@@ -117,8 +117,10 @@ void window_shadow(session_t* ps, win* w, const Vector2* pos, const Vector2* siz
 
         // @CLEANUP: We have to do this since the window isn't using the new nice
         // interface
-        glActiveTexture(GL_TEXTURE0);
-        glBindTexture(GL_TEXTURE_2D, w->paint.ptex->texture);
+        /* glActiveTexture(GL_TEXTURE0); */
+        /* glBindTexture(GL_TEXTURE_2D, w->paint.ptex->texture); */
+        assert(w->drawable.bound);
+        texture_bind(&w->drawable.texture, GL_TEXTURE0);
 
         struct shader_program* global_program = assets_load("shadow.shader");
         if(global_program->shader_type_info != &global_info) {

--- a/src/shadow.c
+++ b/src/shadow.c
@@ -83,7 +83,7 @@ void window_shadow(session_t* ps, win* w, const Vector2* pos, const Vector2* siz
 
     glEnable(GL_BLEND);
 
-    if(!vec2_eq(size, &cache->wSize) || true) {
+    if(!vec2_eq(size, &cache->wSize)) {
         // @BUG: If the size is 0 we will never initialize.
         if(!cache->initialized) {
             shadow_cache_init(cache, size);

--- a/src/shadow.c
+++ b/src/shadow.c
@@ -100,6 +100,8 @@ void window_shadow(session_t* ps, win* w, const Vector2* pos, const Vector2* siz
         framebuffer_targetTexture(&framebuffer, &cache->texture);
         framebuffer_targetRenderBuffer_stencil(&framebuffer, &cache->stencil);
         framebuffer_bind(&framebuffer);
+        Matrix old_view = view;
+        view = mat4_orthogonal(0, cache->texture.size.x, 0, cache->texture.size.y, -1, 1);
 
         glViewport(0, 0, cache->texture.size.x, cache->texture.size.y);
 
@@ -126,6 +128,7 @@ void window_shadow(session_t* ps, win* w, const Vector2* pos, const Vector2* siz
         if(global_program->shader_type_info != &global_info) {
             printf_errf("Shader was not a global shader\n");
             framebuffer_delete(&framebuffer);
+            view = old_view;
             return;
         }
 
@@ -138,23 +141,16 @@ void window_shadow(session_t* ps, win* w, const Vector2* pos, const Vector2* siz
         shader_set_uniform_sampler(global_type->tex_scr, 0);
 
         {
-            Vector2 pixeluv = {{1.0f, 1.0f}};
-            vec2_div(&pixeluv, &cache->texture.size);
-
-            Vector2 scale = pixeluv;
-            vec2_mul(&scale, size);
-
-            Vector2 relpos = pixeluv;
-            vec2_mul(&relpos, &cache->border);
 
 #ifdef DEBUG_GLX
             printf_dbgf("SHADOW %f, %f, %f, %f\n", relpos.x, relpos.y, scale.x, scale.y);
 #endif
 
-            draw_rect(face, global_type->mvp, relpos, scale);
+            draw_rect(face, global_type->mvp, cache->border, *size);
         }
 
         glDisable(GL_STENCIL_TEST);
+        view = old_view;
 
         // Do the blur
         struct TextureBlurData blurData = {
@@ -179,6 +175,8 @@ void window_shadow(session_t* ps, win* w, const Vector2* pos, const Vector2* siz
                 glEnable(GL_SCISSOR_TEST);
             return;
         }
+        old_view = view;
+        view = mat4_orthogonal(0, cache->effect.size.x, 0, cache->effect.size.y, -1, 1);
         glViewport(0, 0, cache->effect.size.x, cache->effect.size.y);
 
         glClearColor(0.0, 0.0, 0.0, 0.0);
@@ -190,9 +188,10 @@ void window_shadow(session_t* ps, win* w, const Vector2* pos, const Vector2* siz
         glStencilFunc(GL_EQUAL, 0, 0xFF);
         glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
 
-        draw_tex(ps, face, &cache->texture, &VEC2_ZERO, &VEC2_UNIT);
+        draw_tex(ps, face, &cache->texture, &VEC2_ZERO, &cache->effect.size);
 
         glDisable(GL_STENCIL_TEST);
+        view = old_view;
 
         framebuffer_delete(&framebuffer);
     }
@@ -218,16 +217,7 @@ void window_shadow(session_t* ps, win* w, const Vector2* pos, const Vector2* siz
         vec2_sub(&rpos, &cache->border);
         Vector2 rsize = cache->texture.size;
 
-        Vector2 pixeluv = {{1.0f, 1.0f}};
-        vec2_div(&pixeluv, &root_size);
-
-        Vector2 scale = pixeluv;
-        vec2_mul(&scale, &rsize);
-
-        Vector2 relpos = pixeluv;
-        vec2_mul(&relpos, &rpos);
-
-        draw_tex(ps, face, &cache->effect, &relpos, &scale);
+        draw_tex(ps, face, &cache->effect, &rpos, &rsize);
     }
 
     glDisable(GL_BLEND);

--- a/src/shadow.c
+++ b/src/shadow.c
@@ -201,6 +201,12 @@ void window_shadow(session_t* ps, win* w, const Vector2* pos, const Vector2* siz
 
     glViewport(0, 0, ps->root_width, ps->root_height);
 
+    struct shader_program* global_program = assets_load("passthough.shader");
+    if(global_program->shader_type_info != &passthough_info) {
+        printf_errf("Shader was not a passthough shader\n");
+        return;
+    }
+
     /* { */
     /*     Vector2 rpos = {{0, 0}}; */
     /*     Vector2 rsize = {{.4, .6}}; */

--- a/src/shadow.c
+++ b/src/shadow.c
@@ -203,12 +203,6 @@ void window_shadow(session_t* ps, win* w, const Vector2* pos, const Vector2* siz
 
     glViewport(0, 0, ps->root_width, ps->root_height);
 
-    struct shader_program* global_program = assets_load("passthough.shader");
-    if(global_program->shader_type_info != &passthough_info) {
-        printf_errf("Shader was not a passthough shader\n");
-        return;
-    }
-
     /* { */
     /*     Vector2 rpos = {{0, 0}}; */
     /*     Vector2 rsize = {{.4, .6}}; */

--- a/src/texture.c
+++ b/src/texture.c
@@ -15,14 +15,26 @@ static inline GLuint generate_texture(GLenum tex_tgt, const Vector2* size) {
   glTexParameteri(tex_tgt, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
   glTexParameteri(tex_tgt, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
   glTexParameteri(tex_tgt, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-  glTexImage2D(tex_tgt, 0, GL_RGBA, size->x, size->y, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
-
-  glBindTexture(tex_tgt, 0);
 
   return tex;
 }
 
 int texture_init(struct Texture* texture, GLenum target, const Vector2* size) {
+    texture->gl_texture = generate_texture(target, size);
+    if(texture->gl_texture == 0) {
+        return 1;
+    }
+
+    texture->target = target;
+    texture->size = *size;
+
+    glTexImage2D(texture->target, 0, GL_RGBA, size->x, size->y, 0, GL_RGBA,
+            GL_UNSIGNED_BYTE, NULL);
+
+    return 0;
+}
+
+int texture_init_nospace(struct Texture* texture, GLenum target, const Vector2* size) {
     texture->gl_texture = generate_texture(target, size);
     if(texture->gl_texture == 0) {
         return 1;

--- a/src/texture.c
+++ b/src/texture.c
@@ -41,7 +41,8 @@ int texture_init_nospace(struct Texture* texture, GLenum target, const Vector2* 
     }
 
     texture->target = target;
-    texture->size = *size;
+    if(size != NULL)
+        texture->size = *size;
 
     return 0;
 }

--- a/src/texture.h
+++ b/src/texture.h
@@ -12,6 +12,7 @@ struct Texture {
 };
 
 int texture_init(struct Texture* texture, GLenum target, const Vector2* size);
+int texture_init_nospace(struct Texture* texture, GLenum target, const Vector2* size);
 void texture_delete(struct Texture* texture);
 bool texture_initialized(const struct Texture* texture);
 

--- a/src/texture.h
+++ b/src/texture.h
@@ -8,7 +8,10 @@
 struct Texture {
     GLuint gl_texture;
     GLenum target;
+
     Vector2 size;
+
+    bool flipped;
 };
 
 int texture_init(struct Texture* texture, GLenum target, const Vector2* size);

--- a/src/vmath.c
+++ b/src/vmath.c
@@ -76,7 +76,7 @@ bool vec##n##_eq(const Vector##n * a, const Vector##n * b)                   \
 }
 
 #define DEFINE_VEC_CONST(n, k)                                          \
-Vector##n vec##n##_from_vec##k (const Vector##n * const v, ...) {       \
+Vector##n vec##n##_from_vec##k (const Vector##k * const v, ...) {       \
     va_list args;                                                       \
     va_start(args, v);                                                  \
                                                                         \
@@ -91,8 +91,11 @@ Vector##n vec##n##_from_vec##k (const Vector##n * const v, ...) {       \
 }
 
 DEFINE_VEC_OPS(2)
+DEFINE_VEC_OPS(3)
 DEFINE_VEC_OPS(4)
 DEFINE_VEC_CONST(4, 2)
+DEFINE_VEC_CONST(3, 2)
+DEFINE_VEC_CONST(4, 3)
 
 #undef DEFINE_VEC_CONST
 #undef DEFINE_VEC_OPS
@@ -221,14 +224,17 @@ Matrix perspective(float fovy, float aspect_ratio, float near_plane, float far_p
     return out;
 }
 
-Matrix orthogonal(float left, float right, float bottom, float top, float near, float far) {
+Matrix mat4_orthogonal(float left, float right, float bottom, float top, float near, float far) {
     Matrix out = IDENTITY_MATRIX;
     out.m[0] = 2 / (right - left);
     out.m[5] = 2 / (top - bottom);
     out.m[10] = -2 / (far - near);
+
     out.m[12] = - (right + left) / (right - left);
     out.m[13] = - (top + bottom) / (top - bottom);
     out.m[14] = - (far + near) / (far - near);
+
+    out.m[15] = 1;
 
     return out;
 }

--- a/src/vmath.h
+++ b/src/vmath.h
@@ -25,7 +25,7 @@ void mat4_translate(Matrix* const m, float x, float y, float z);
 Matrix mat4_multiply(const Matrix* m1, const Matrix* m2);
 
 Matrix perspective(float fovy, float aspect_ratio, float near_plane, float far_plane);
-Matrix orthogonal(float left, float right, float bottom, float top, float near, float far);
+Matrix mat4_orthogonal(float left, float right, float bottom, float top, float near, float far);
 
 // Vector operations {{{
 #define DEFINE_VEC_OPS(n)                                                     \
@@ -45,7 +45,7 @@ void vec##n##_clamp(Vector##n * a, const Vector##n * b, const Vector##n * c); \
 bool vec##n##_eq(const Vector##n * a, const Vector##n * b);                   \
 
 #define DEFINE_VEC_CONST(n, k) \
-    Vector##n vec##n##_from_vec##k (const Vector##n * const v, ...);
+    Vector##n vec##n##_from_vec##k (const Vector##k * const v, ...);
 // }}}
 
 typedef union Vector4 {
@@ -71,6 +71,19 @@ Vector4 mat4_vec4_mul(const Matrix* m, const Vector4* v);
 
 Matrix lookAt(Vector4 pos, Vector4 dir);
 
+typedef union Vector3 {
+    float m[3];
+    struct {
+        float x, y, z;
+    };
+} Vector3;
+
+static const Vector3 VEC3_ZERO = {{0, 0, 0}};
+static const Vector3 VEC3_UNIT = {{1, 1, 1}};
+
+DEFINE_VEC_OPS(3)
+DEFINE_VEC_CONST(4, 3)
+
 typedef union Vector2 {
     float m[2];
     struct {
@@ -85,6 +98,7 @@ static const Vector2 VEC2_ZERO = {{0, 0}};
 static const Vector2 VEC2_UNIT = {{1, 1}};
 
 DEFINE_VEC_OPS(2)
+DEFINE_VEC_CONST(3, 2)
 DEFINE_VEC_CONST(4, 2)
 
 #undef DEFINE_VEC_CONST

--- a/src/window.c
+++ b/src/window.c
@@ -1,6 +1,11 @@
 #include "window.h"
 
 #include "vmath.h"
+#include "blur.h"
+#include "assets/assets.h"
+#include "assets/shader.h"
+#include "shaders/shaderinfo.h"
+#include "textureeffects.h"
 
 bool win_overlap(win* w1, win* w2) {
     const Vector2 w1lpos = {{
@@ -15,11 +20,11 @@ bool win_overlap(win* w1, win* w2) {
     const Vector2 w2rpos = {{
         w2->a.x + w2->widthb, w2->a.y + w2->heightb,
     }};
-    // If one rectangle is on left side of other
+    // Horizontal collision
     if (w1lpos.x > w2rpos.x || w2lpos.x > w1rpos.x)
         return false;
 
-    // If one rectangle is above other
+    // Vertical collision
     if (w1lpos.y > w2rpos.y || w2lpos.y > w1rpos.y)
         return false;
 
@@ -31,4 +36,104 @@ bool win_covers(win* w) {
         && (!w->has_frame || !w->frame_opacity)
         && w->fullscreen
         && !w->unredir_if_possible_excluded;
+}
+
+static Vector2 X11_rectpos_to_gl(session_t *ps, const Vector2* xpos, const Vector2* size) {
+    Vector2 glpos = {{
+        xpos->x, ps->root_height - xpos->y - size->y
+    }};
+    return glpos;
+}
+
+bool win_calculate_blur(struct blur* blur, session_t* ps, win* w) {
+    const bool have_scissors = glIsEnabled(GL_SCISSOR_TEST);
+    const bool have_stencil = glIsEnabled(GL_STENCIL_TEST);
+
+    Vector2 pos = {{w->a.x, w->a.y}};
+    Vector2 size = {{w->widthb, w->heightb}};
+    if(blur_cache_init(&w->glx_blur_cache, &size) != 0) {
+        printf_errf("(): Failed to initializing cache");
+        return false;
+    }
+
+    if(w->glx_blur_cache.damaged) {
+        struct Texture* tex = &w->glx_blur_cache.texture[0];
+        // Read destination pixels into a texture
+
+        Vector2 glpos = X11_rectpos_to_gl(ps, &pos, &size);
+        /* texture_read_from(tex, 0, GL_BACK, &glpos, &size); */
+
+        framebuffer_resetTarget(&blur->fbo);
+        framebuffer_targetTexture(&blur->fbo, tex);
+        framebuffer_bind(&blur->fbo);
+
+        glDisable(GL_STENCIL_TEST);
+        glDisable(GL_SCISSOR_TEST);
+
+        glClearColor(1.0, 0.0, 0.0, 1.0);
+        glClear(GL_COLOR_BUFFER_BIT);
+
+        glViewport(0, 0, size.x, size.y);
+
+        struct shader_program* global_program = assets_load("passthough.shader");
+        if(global_program->shader_type_info != &passthough_info) {
+            printf_errf("Shader was not a passthough shader\n");
+            return false;
+        }
+
+        struct face* face = assets_load("window.face");
+
+        Vector2 root_size = size;
+        Vector2 pixeluv = {{1.0f, 1.0f}};
+        vec2_div(&pixeluv, &tex->size);
+
+        for(win* t = w->next_trans; t != NULL; t = t->next_trans) {
+            Vector2 tpos = {{t->a.x, t->a.y}};
+            Vector2 tsize = {{t->widthb, t->heightb}};
+            Vector2 tglpos = X11_rectpos_to_gl(ps, &tpos, &tsize);
+            vec2_sub(&tglpos, &glpos);
+
+            Vector2 scale = pixeluv;
+            vec2_mul(&scale, &tsize);
+
+            Vector2 relpos = pixeluv;
+            vec2_mul(&relpos, &tglpos);
+            printf("SHADOW_DRAW %f %f x %f %f\n", relpos.x, relpos.y, scale.x, scale.y);
+
+            draw_tex(ps, face, &t->glx_blur_cache.texture[0], &relpos, &scale);
+            struct Texture ttt = {
+                .target = GL_TEXTURE_2D,
+                .gl_texture = t->paint.ptex->texture,
+                /* .gl_texture = ps->root_tile_paint.ptex->texture, */
+            };
+            draw_tex(ps, face, &ttt, &relpos, &scale);
+        }
+
+        // Texture scaling factor
+        Vector2 halfpixel = pixeluv;
+        vec2_idiv(&halfpixel, 2);
+
+        // Disable the options. We will restore later
+        glDisable(GL_STENCIL_TEST);
+        glDisable(GL_SCISSOR_TEST);
+
+        int level = ps->o.blur_level;
+
+        struct TextureBlurData blurData = {
+            .buffer = &blur->fbo,
+            .swap = &w->glx_blur_cache.texture[1],
+        };
+        // Do the blur
+        if(!texture_blur(&blurData, tex, level, false)) {
+            printf_errf("Failed blurring the background texture");
+
+            if (have_scissors)
+                glEnable(GL_SCISSOR_TEST);
+            if (have_stencil)
+                glEnable(GL_STENCIL_TEST);
+            return false;
+        }
+        w->glx_blur_cache.damaged = false;
+    }
+    return true;
 }

--- a/src/window.c
+++ b/src/window.c
@@ -60,31 +60,29 @@ bool win_calculate_blur(struct blur* blur, session_t* ps, win* w) {
         Vector2 glpos = X11_rectpos_to_gl(ps, &pos, &size);
         texture_read_from(tex, 0, GL_BACK, &glpos, &size);
 
-        framebuffer_resetTarget(&blur->fbo);
-        framebuffer_targetTexture(&blur->fbo, tex);
-        framebuffer_bind(&blur->fbo);
+        /* framebuffer_resetTarget(&blur->fbo); */
+        /* framebuffer_targetTexture(&blur->fbo, tex); */
+        /* framebuffer_bind(&blur->fbo); */
 
-        glDisable(GL_STENCIL_TEST);
-        glDisable(GL_SCISSOR_TEST);
+        /* glDisable(GL_STENCIL_TEST); */
+        /* glDisable(GL_SCISSOR_TEST); */
 
-        glClearColor(1.0, 0.0, 0.0, 1.0);
-        glClear(GL_COLOR_BUFFER_BIT);
+        /* glClearColor(1.0, 1.0, 0.0, 1.0); */
+        /* glClear(GL_COLOR_BUFFER_BIT); */
 
-        glViewport(0, 0, size.x, size.y);
+        /* glViewport(0, 0, size.x, size.y); */
 
-        struct shader_program* global_program = assets_load("passthough.shader");
-        if(global_program->shader_type_info != &passthough_info) {
-            printf_errf("Shader was not a passthough shader\n");
-            return false;
-        }
+        /* struct shader_program* global_program = assets_load("passthough.shader"); */
+        /* if(global_program->shader_type_info != &passthough_info) { */
+        /*     printf_errf("Shader was not a passthough shader\n"); */
+        /*     return false; */
+        /* } */
 
-        struct face* face = assets_load("window.face");
+        /* struct face* face = assets_load("window.face"); */
 
-        texture_read_from(tex, 0, GL_BACK, &glpos, &size);
-
-        Vector2 root_size = size;
-        Vector2 pixeluv = {{1.0f, 1.0f}};
-        vec2_div(&pixeluv, &tex->size);
+        /* Vector2 root_size = size; */
+        /* Vector2 pixeluv = {{1.0f, 1.0f}}; */
+        /* vec2_div(&pixeluv, &tex->size); */
 
         /* for(win* t = w->next_trans; t != NULL; t = t->next_trans) { */
         /*     Vector2 tpos = {{t->a.x, t->a.y}}; */
@@ -108,8 +106,8 @@ bool win_calculate_blur(struct blur* blur, session_t* ps, win* w) {
         /* } */
 
         // Texture scaling factor
-        Vector2 halfpixel = pixeluv;
-        vec2_idiv(&halfpixel, 2);
+        /* Vector2 halfpixel = pixeluv; */
+        /* vec2_idiv(&halfpixel, 2); */
 
         // Disable the options. We will restore later
         glDisable(GL_STENCIL_TEST);

--- a/src/window.c
+++ b/src/window.c
@@ -138,14 +138,72 @@ bool win_calculate_blur(struct blur* blur, session_t* ps, win* w) {
     return true;
 }
 
-bool wd_bind(struct WindowDrawable* drawable, Display* display, Window wid) {
+bool wd_init(struct WindowDrawable* drawable, struct X11Context* context, Window wid) {
+    assert(drawable != NULL);
+    assert(context != NULL);
+
+    drawable->context = context;
     drawable->wid = wid;
-    drawable->pixmap = XCompositeNameWindowPixmap(display, wid);
+    return true;
+}
+
+bool wd_bind(struct WindowDrawable* drawable) {
+    assert(drawable != NULL);
+    assert(!drawable->bound);
+
+    drawable->pixmap = XCompositeNameWindowPixmap(drawable->context->display, drawable->wid);
     if(drawable->pixmap == 0) {
         printf_errf("Failed getting window pixmap");
         return false;
     }
+
+    const int attrib[] = {
+        GLX_TEXTURE_TARGET_EXT, GLX_TEXTURE_2D_EXT,
+        GLX_TEXTURE_FORMAT_EXT, GLX_TEXTURE_FORMAT_RGBA_EXT,
+        None,
+    };
+    drawable->glxPixmap = glXCreatePixmap(
+            drawable->context->display,
+            drawable->context->selected_config,
+            drawable->pixmap,
+            attrib
+            );
+    Window root;
+    int rx,  ry;
+    uint32_t width, height;
+    uint32_t border;
+    uint32_t depth;
+    if(!XGetGeometry(drawable->context->display, drawable->pixmap, &root, &rx,
+                &ry, &width, &height, &border, &depth)) {
+        printf_errf("Failed querying pixmap info for %#010lx", drawable->pixmap);
+        // @INCOMPLETE: free
+        return false;
+    }
+    Vector2 size = {{width, height}};
+
+    texture_init_nospace(&drawable->texture, GL_TEXTURE_2D, &size);
+
+    glXBindTexImageEXT(drawable->context->display, drawable->glxPixmap,
+            GLX_FRONT_LEFT_EXT, NULL);
+
+    drawable->bound = true;
     return true;
 }
+
+bool wd_unbind(struct WindowDrawable* drawable) {
+    assert(drawable != NULL);
+    assert(drawable->bound);
+    texture_bind(&drawable->texture, GL_TEXTURE0);
+    glXReleaseTexImageEXT(drawable->context->display, drawable->pixmap,
+            GLX_FRONT_LEFT_EXT);
+    glXDestroyPixmap(drawable->context->display, drawable->pixmap);
+    texture_delete(&drawable->texture);
+    return true;
+}
+
 void wd_delete(struct WindowDrawable* drawable) {
+    assert(drawable != NULL);
+    if(drawable->bound) {
+        wd_unbind(drawable);
+    }
 }

--- a/src/window.c
+++ b/src/window.c
@@ -52,17 +52,13 @@ bool win_calculate_blur(struct blur* blur, session_t* ps, win* w) {
 
     Vector2 pos = {{w->a.x, w->a.y}};
     Vector2 size = {{w->widthb, w->heightb}};
-    if(blur_cache_init(&w->glx_blur_cache, &size) != 0) {
-        printf_errf("(): Failed to initializing cache");
-        return false;
-    }
 
     if(w->glx_blur_cache.damaged) {
         struct Texture* tex = &w->glx_blur_cache.texture[0];
         // Read destination pixels into a texture
 
         Vector2 glpos = X11_rectpos_to_gl(ps, &pos, &size);
-        /* texture_read_from(tex, 0, GL_BACK, &glpos, &size); */
+        texture_read_from(tex, 0, GL_BACK, &glpos, &size);
 
         framebuffer_resetTarget(&blur->fbo);
         framebuffer_targetTexture(&blur->fbo, tex);

--- a/src/window.c
+++ b/src/window.c
@@ -137,3 +137,15 @@ bool win_calculate_blur(struct blur* blur, session_t* ps, win* w) {
     }
     return true;
 }
+
+bool wd_bind(struct WindowDrawable* drawable, Display* display, Window wid) {
+    drawable->wid = wid;
+    drawable->pixmap = XCompositeNameWindowPixmap(display, wid);
+    if(drawable->pixmap == 0) {
+        printf_errf("Failed getting window pixmap");
+        return false;
+    }
+    return true;
+}
+void wd_delete(struct WindowDrawable* drawable) {
+}

--- a/src/window.h
+++ b/src/window.h
@@ -1,7 +1,22 @@
 #pragma once
 
+#define GL_GLEXT_PROTOTYPES
+#include <GL/glx.h>
+
 #include "common.h"
 
 bool win_overlap(win* w1, win* w2);
 bool win_covers(win* w);
 bool win_is_solid(win* w);
+
+struct WindowDrawable {
+    Window wid;
+
+    bool bound;
+    Pixmap pixmap;
+    GLXDrawable glxPixmap;
+    struct Texture* texture;
+};
+
+bool wd_bind(struct WindowDrawable* drawable, Display* display, Window wid);
+void wd_delete(struct WindowDrawable* drawable);

--- a/src/window.h
+++ b/src/window.h
@@ -9,14 +9,8 @@ bool win_overlap(win* w1, win* w2);
 bool win_covers(win* w);
 bool win_is_solid(win* w);
 
-struct WindowDrawable {
-    Window wid;
-
-    bool bound;
-    Pixmap pixmap;
-    GLXDrawable glxPixmap;
-    struct Texture* texture;
-};
-
-bool wd_bind(struct WindowDrawable* drawable, Display* display, Window wid);
+bool wd_init(struct WindowDrawable* drawable, struct X11Context* context, Window wid);
 void wd_delete(struct WindowDrawable* drawable);
+
+bool wd_bind(struct WindowDrawable* drawable);
+bool wd_unbind(struct WindowDrawable* drawable);

--- a/src/xorg.c
+++ b/src/xorg.c
@@ -1,0 +1,75 @@
+#include "xorg.h"
+
+#include "assert.h"
+
+bool xorgContext_init(struct X11Context* context, Display* display, int screen) {
+    assert(context != NULL);
+    assert(display != NULL);
+
+    context->display = display;
+    context->screen = screen;
+
+    context->selected = false;
+
+    context->configs = glXGetFBConfigs(display, screen, &context->numConfigs);
+    if(context->configs == NULL) {
+        printf_errf("Failed retrieving the fboconfigs");
+        return false;
+    }
+
+    return true;
+}
+
+bool xorgContext_selectConfig(struct X11Context* context, VisualID visualid) {
+    assert(context->selected == false);
+    assert(visualid != 0);
+
+    int value;
+    for(int i = 0; i < context->numConfigs; i++) {
+        GLXFBConfig fbconfig = context->configs[i];
+        XVisualInfo* visinfo = glXGetVisualFromFBConfig(context->display, fbconfig);
+        if (!visinfo || visinfo->visualid != visualid)
+            continue;
+
+        // We don't want to use anything multisampled
+        glXGetFBConfigAttrib(context->display, fbconfig, GLX_SAMPLES, &value);
+        if (value >= 2)
+            continue;
+
+        // We need to support pixmaps
+        glXGetFBConfigAttrib(context->display, fbconfig, GLX_DRAWABLE_TYPE, &value);
+        if (!(value & GLX_PIXMAP_BIT))
+            continue;
+
+        // We need to be able to bind pixmaps to textures
+        glXGetFBConfigAttrib(context->display, fbconfig,
+                GLX_BIND_TO_TEXTURE_TARGETS_EXT,
+                &value);
+        if (!(value & GLX_TEXTURE_2D_BIT_EXT))
+            continue;
+
+        // We want RGBA textures
+        glXGetFBConfigAttrib(context->display, fbconfig,
+                GLX_BIND_TO_TEXTURE_RGBA_EXT, &value);
+        if (value == false)
+            continue;
+
+        // We found something we like
+        context->selected = true;
+        context->selected_config = fbconfig;
+        break;
+    }
+    // If we ran out of fbconfigs before we found something we like.
+    if(context->selected == false)
+        return false;
+
+    // Save if the y is inverted compared to GL
+    glXGetFBConfigAttrib(context->display, context->selected_config,
+            GLX_Y_INVERTED_EXT, &value);
+    context->y_inverted = value;
+    return true;
+}
+
+void xorgContext_delete(struct X11Context* context) {
+    assert(context->display != NULL);
+}

--- a/src/xorg.h
+++ b/src/xorg.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#define GL_GLEXT_PROTOTYPES
+#include <GL/glx.h>
+
+#include <stdbool.h>
+#include <stdio.h>
+
+/// Print out an error message.
+#define printf_err(format, ...) \
+  fprintf(stderr, format "\n", ## __VA_ARGS__)
+
+/// Print out an error message with function name.
+#define printf_errf(format, ...) \
+  printf_err("%s(): " format,  __func__, ## __VA_ARGS__)
+
+struct X11Context {
+    Display* display;
+    int screen;
+    GLXFBConfig* configs;
+    int numConfigs;
+
+    bool selected;
+    GLXFBConfig selected_config;
+
+    bool y_inverted;
+};
+
+bool xorgContext_init(struct X11Context* context, Display* display, int screen);
+
+bool xorgContext_selectConfig(struct X11Context* context, VisualID visualid);
+
+void xorgContext_delete(struct X11Context* context);

--- a/src/xtexture.c
+++ b/src/xtexture.c
@@ -1,0 +1,79 @@
+#include "xtexture.h"
+
+bool xtexture_init(struct XTexture* tex, struct X11Context* context) {
+    assert(tex != NULL);
+    assert(context != NULL);
+
+    tex->context = context;
+    tex->pixmap = 0;
+    texture_init_nospace(&tex->texture, GL_TEXTURE_2D, NULL);
+    //If the context says textures pixmaps are inverted, then we need to tell
+    //the texture
+    tex->texture.flipped = context->y_inverted;
+    return true;
+}
+
+void xtexture_delete(struct XTexture* tex) {
+    assert(tex != NULL);
+    if(tex->bound) {
+        xtexture_unbind(tex);
+    }
+    texture_delete(&tex->texture);
+}
+
+bool xtexture_bind(struct XTexture* tex, Pixmap pixmap) {
+    assert(tex != NULL);
+    assert(!tex->bound);
+
+    tex->pixmap = pixmap;
+
+    Window root;
+    int rx,  ry;
+    uint32_t width, height;
+    uint32_t border;
+    uint32_t depth;
+    if(!XGetGeometry(tex->context->display, tex->pixmap, &root, &rx,
+                &ry, &width, &height, &border, &depth)) {
+        printf_errf("Failed querying pixmap info for %#010lx", tex->pixmap);
+        // @INCOMPLETE: free
+        return false;
+    }
+
+    Vector2 size = {{width, height}};
+
+    const int attrib[] = {
+        GLX_TEXTURE_TARGET_EXT, GLX_TEXTURE_2D_EXT,
+        GLX_TEXTURE_FORMAT_EXT, GLX_TEXTURE_FORMAT_RGBA_EXT,
+        None,
+    };
+    tex->glxPixmap = glXCreatePixmap(
+            tex->context->display,
+            tex->context->selected_config,
+            tex->pixmap,
+            attrib
+            );
+
+    tex->texture.size = size;
+
+    texture_bind(&tex->texture, GL_TEXTURE0);
+    glXBindTexImageEXT(tex->context->display, tex->glxPixmap,
+            GLX_FRONT_LEFT_EXT, NULL);
+
+    tex->bound = true;
+    return true;
+}
+
+bool xtexture_unbind(struct XTexture* tex) {
+    assert(tex != NULL);
+    assert(tex->bound);
+
+    texture_bind(&tex->texture, GL_TEXTURE0);
+    glXReleaseTexImageEXT(tex->context->display, tex->pixmap,
+            GLX_FRONT_LEFT_EXT);
+
+    glXDestroyPixmap(tex->context->display, tex->pixmap);
+    tex->pixmap = 0;
+
+    tex->bound = false;
+    return true;
+}

--- a/src/xtexture.c
+++ b/src/xtexture.c
@@ -71,7 +71,8 @@ bool xtexture_unbind(struct XTexture* tex) {
     glXReleaseTexImageEXT(tex->context->display, tex->pixmap,
             GLX_FRONT_LEFT_EXT);
 
-    glXDestroyPixmap(tex->context->display, tex->pixmap);
+    glXDestroyPixmap(tex->context->display, tex->glxPixmap);
+    XFreePixmap(tex->context->display, tex->pixmap);
     tex->pixmap = 0;
 
     tex->bound = false;

--- a/src/xtexture.h
+++ b/src/xtexture.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#define GL_GLEXT_PROTOTYPES
+#include <GL/glx.h>
+
+#include "common.h"
+
+#include "texture.h"
+
+bool xtexture_init(struct XTexture* tex, struct X11Context* context);
+void xtexture_delete(struct XTexture* tex);
+
+bool xtexture_bind(struct XTexture* tex, Pixmap pixmap);
+bool xtexture_unbind(struct XTexture* tex);


### PR DESCRIPTION
Rework some of the pixmap binding to happen based on events, instead of during drawing.

This is part of a larger effort to separate rendering and updating, so that we can do all the CPU work while the GPU is rendering. Games have been doing this for years, I don't understand why we haven't.