### PR TITLE
Fix missing declaration

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -2333,6 +2333,7 @@ xr_sync_(session_t *ps, Drawable d
     if (!*pfence)
       *pfence = XSyncCreateFence(ps->dpy, d, False);
     if (*pfence) {
+      Bool triggered = False;
       /* if (XSyncQueryFence(ps->dpy, *pfence, &triggered) && triggered)
         XSyncResetFence(ps->dpy, *pfence); */
       // The fence may fail to be created (e.g. because of died drawable)


### PR DESCRIPTION
I don't know if the dropping of this line but leaving the rest of this function was intentional, but I couldn't get this to compile without adding this back. 
(Been using this as a daily in-place of compton otherwise :D I vote rename to glendale)